### PR TITLE
Don't silently swallow invalid candidate exception

### DIFF
--- a/src/aioice/ice.py
+++ b/src/aioice/ice.py
@@ -364,7 +364,8 @@ class Connection:
         # validate the remote candidate
         try:
             validate_remote_candidate(remote_candidate)
-        except ValueError:
+        except ValueError as e:
+            self.__log_info(f"Candidate not valid: {e}")
             return
         self._remote_candidates.append(remote_candidate)
 


### PR DESCRIPTION
Until #14 is fixed, aioice doesn't work with Chrome until STUN candidates come through, because it doesn't get a valid IP from the initial set of candidates. However, thanks to `_early_checks`, it does work in ICE-CONTROLLING mode, as long as `request_received` is called before `_connect`. In practice, this means the `cli.py offer` copy/paste example works, but none of the others do unless you add `asyncio.sleep(1)` before `pc.setRemoteDescription`.

To make it clear that the candidates are being rejected, this PR logs out instead of silently swallowing an invalid candidate.

As a secondary thing, I can't tell whether the `_early_checks` behaviour is correct. I don't know whether ICE should work with no candidates (Chrome doesn't even try to connect if there are no channels on a connection), but it seems to me that once you've called `_connect`, candidates could go into `_check_list` rather than `_early_checks`. There's no guarantee a peer will send any more candidates after the initial answer, is there?
