### PR TITLE
Use modern asyncio.wait() syntax to avoid deprecation warning

### DIFF
--- a/src/aioice/ice.py
+++ b/src/aioice/ice.py
@@ -809,12 +809,16 @@ class Connection:
 
         # query STUN server for server-reflexive candidates (IPv4 only)
         if self.stun_server:
-            fs = []
+            tasks = []
             for protocol in self._protocols:
                 if ipaddress.ip_address(protocol.local_candidate.host).version == 4:
-                    fs.append(server_reflexive_candidate(protocol, self.stun_server))
-            if len(fs):
-                done, pending = await asyncio.wait(fs, timeout=timeout)
+                    tasks.append(
+                        asyncio.ensure_future(
+                            server_reflexive_candidate(protocol, self.stun_server)
+                        )
+                    )
+            if len(tasks):
+                done, pending = await asyncio.wait(tasks, timeout=timeout)
                 candidates += [
                     task.result() for task in done if task.exception() is None
                 ]

--- a/tests/test_ice.py
+++ b/tests/test_ice.py
@@ -469,7 +469,10 @@ class IceConnectionTest(unittest.TestCase):
         # connect
         done, pending = run(
             asyncio.wait(
-                [conn_a.connect(), conn_b.connect()],
+                [
+                    asyncio.ensure_future(conn_a.connect()),
+                    asyncio.ensure_future(conn_b.connect()),
+                ],
                 return_when=asyncio.FIRST_EXCEPTION,
             )
         )
@@ -503,7 +506,14 @@ class IceConnectionTest(unittest.TestCase):
         conn_a.remote_password = conn_b.local_password
 
         # connect
-        done, pending = run(asyncio.wait([conn_a.connect(), conn_b.connect()]))
+        done, pending = run(
+            asyncio.wait(
+                [
+                    asyncio.ensure_future(conn_a.connect()),
+                    asyncio.ensure_future(conn_b.connect()),
+                ]
+            )
+        )
         for task in pending:
             task.cancel()
         self.assertEqual(len(done), 2)


### PR DESCRIPTION
Since Python 3.8, we need to wrap coroutines in a task before passing
them to asyncio.wait().

Until Python 3.6 support is dropped we cannot use asyncio.create_task(),
so use the less readable asyncio.ensure_future().