### PR TITLE
[breaking] make add_remote_candidate a coroutine

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,13 @@
+Changelog
+=========
+
+.. currentmodule:: aioice
+
+0.7.0
+-----
+
+Breaking
+........
+
+ * Make :meth:`Connection.add_remote_candidate` a coroutine.
+ * Remove the deprecated `Connection.remote_candidates` setter.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,4 +33,5 @@ Typical usecases include SIP and WebRTC.
    :maxdepth: 2
 
    api
+   changelog
    license

--- a/examples/ice-client.py
+++ b/examples/ice-client.py
@@ -36,8 +36,8 @@ async def offer(options):
     message = json.loads(await websocket.recv())
     print("received answer", message)
     for c in message["candidates"]:
-        connection.add_remote_candidate(aioice.Candidate.from_sdp(c))
-    connection.add_remote_candidate(None)
+        await connection.add_remote_candidate(aioice.Candidate.from_sdp(c))
+    await connection.add_remote_candidate(None)
     connection.remote_username = message["username"]
     connection.remote_password = message["password"]
 
@@ -70,8 +70,8 @@ async def answer(options):
     message = json.loads(await websocket.recv())
     print("received offer", message)
     for c in message["candidates"]:
-        connection.add_remote_candidate(aioice.Candidate.from_sdp(c))
-    connection.add_remote_candidate(None)
+        await connection.add_remote_candidate(aioice.Candidate.from_sdp(c))
+    await connection.add_remote_candidate(None)
     connection.remote_username = message["username"]
     connection.remote_password = message["password"]
 

--- a/src/aioice/ice.py
+++ b/src/aioice/ice.py
@@ -5,7 +5,6 @@ import logging
 import random
 import secrets
 import socket
-import warnings
 from itertools import count
 from typing import Dict, List, Optional, Set, Text, Tuple, Union, cast
 
@@ -324,22 +323,7 @@ class Connection:
         """
         return self._remote_candidates[:]
 
-    @remote_candidates.setter
-    def remote_candidates(self, value: List[Candidate]) -> None:
-        warnings.warn(
-            "Assigning Connection.remote_candidates is deprecated, use add_remote_candidate",
-            category=DeprecationWarning,
-        )
-        if self._remote_candidates_end:
-            raise ValueError("Cannot set remote candidates after end-of-candidates.")
-
-        # replace remote candidates then signal end-of-candidates
-        self._remote_candidates = []
-        for remote_candidate in value:
-            self.add_remote_candidate(remote_candidate)
-        self.add_remote_candidate(None)
-
-    def add_remote_candidate(self, remote_candidate: Candidate) -> None:
+    async def add_remote_candidate(self, remote_candidate: Candidate) -> None:
         """
         Add a remote candidate or signal end-of-candidates.
 

--- a/tests/test_ice.py
+++ b/tests/test_ice.py
@@ -3,7 +3,6 @@ import functools
 import os
 import socket
 import unittest
-import warnings
 from unittest import mock
 
 from aioice import Candidate, ice, stun
@@ -453,16 +452,16 @@ class IceConnectionTest(unittest.TestCase):
         # invite
         run(conn_a.gather_candidates())
         for candidate in conn_a.local_candidates:
-            conn_b.add_remote_candidate(candidate)
-        conn_b.add_remote_candidate(None)
+            run(conn_b.add_remote_candidate(candidate))
+        run(conn_b.add_remote_candidate(None))
         conn_b.remote_username = conn_a.local_username
         conn_b.remote_password = conn_a.local_password
 
         # accept
         run(conn_b.gather_candidates())
         for candidate in conn_b.local_candidates:
-            conn_a.add_remote_candidate(candidate)
-        conn_a.add_remote_candidate(None)
+            run(conn_a.add_remote_candidate(candidate))
+        run(conn_a.add_remote_candidate(None))
         conn_a.remote_username = conn_b.local_username
         conn_a.remote_password = "wrong-password"
 
@@ -492,16 +491,16 @@ class IceConnectionTest(unittest.TestCase):
         # invite
         run(conn_a.gather_candidates())
         for candidate in conn_a.local_candidates:
-            conn_b.add_remote_candidate(candidate)
-        conn_b.add_remote_candidate(None)
+            run(conn_b.add_remote_candidate(candidate))
+        run(conn_b.add_remote_candidate(None))
         conn_b.remote_username = conn_a.local_username
         conn_b.remote_password = conn_a.local_password
 
         # accept
         run(conn_b.gather_candidates())
         for candidate in conn_b.local_candidates:
-            conn_a.add_remote_candidate(candidate)
-        conn_a.add_remote_candidate(None)
+            run(conn_a.add_remote_candidate(candidate))
+        run(conn_a.add_remote_candidate(None))
         conn_a.remote_username = "wrong-username"
         conn_a.remote_password = conn_b.local_password
 
@@ -529,12 +528,14 @@ class IceConnectionTest(unittest.TestCase):
         If local candidates gathering was not performed, connect fails.
         """
         conn = ice.Connection(ice_controlling=True)
-        conn.add_remote_candidate(
-            Candidate.from_sdp(
-                "6815297761 1 udp 659136 1.2.3.4 31102 typ host generation 0"
+        run(
+            conn.add_remote_candidate(
+                Candidate.from_sdp(
+                    "6815297761 1 udp 659136 1.2.3.4 31102 typ host generation 0"
+                )
             )
         )
-        conn.add_remote_candidate(None)
+        run(conn.add_remote_candidate(None))
         conn.remote_username = "foo"
         conn.remote_password = "bar"
         with self.assertRaises(ConnectionError) as cm:
@@ -550,12 +551,14 @@ class IceConnectionTest(unittest.TestCase):
         """
         conn = ice.Connection(ice_controlling=True)
         conn._local_candidates_end = True
-        conn.add_remote_candidate(
-            Candidate.from_sdp(
-                "6815297761 1 udp 659136 1.2.3.4 31102 typ host generation 0"
+        run(
+            conn.add_remote_candidate(
+                Candidate.from_sdp(
+                    "6815297761 1 udp 659136 1.2.3.4 31102 typ host generation 0"
+                )
             )
         )
-        conn.add_remote_candidate(None)
+        run(conn.add_remote_candidate(None))
         conn.remote_username = "foo"
         conn.remote_password = "bar"
         with self.assertRaises(ConnectionError) as cm:
@@ -569,7 +572,7 @@ class IceConnectionTest(unittest.TestCase):
         """
         conn = ice.Connection(ice_controlling=True)
         run(conn.gather_candidates())
-        conn.add_remote_candidate(None)
+        run(conn.add_remote_candidate(None))
         conn.remote_username = "foo"
         conn.remote_password = "bar"
         with self.assertRaises(ConnectionError) as cm:
@@ -583,12 +586,14 @@ class IceConnectionTest(unittest.TestCase):
         """
         conn = ice.Connection(ice_controlling=True)
         run(conn.gather_candidates())
-        conn.add_remote_candidate(
-            Candidate.from_sdp(
-                "6815297761 1 udp 659136 1.2.3.4 31102 typ host generation 0"
+        run(
+            conn.add_remote_candidate(
+                Candidate.from_sdp(
+                    "6815297761 1 udp 659136 1.2.3.4 31102 typ host generation 0"
+                )
             )
         )
-        conn.add_remote_candidate(None)
+        run(conn.add_remote_candidate(None))
         with self.assertRaises(ConnectionError) as cm:
             run(conn.connect())
         self.assertEqual(str(cm.exception), "Remote username or password is missing")
@@ -640,12 +645,14 @@ class IceConnectionTest(unittest.TestCase):
 
         conn = ice.Connection(ice_controlling=True)
         run(conn.gather_candidates())
-        conn.add_remote_candidate(
-            Candidate.from_sdp(
-                "6815297761 1 udp 659136 1.2.3.4 31102 typ host generation 0"
+        run(
+            conn.add_remote_candidate(
+                Candidate.from_sdp(
+                    "6815297761 1 udp 659136 1.2.3.4 31102 typ host generation 0"
+                )
             )
         )
-        conn.add_remote_candidate(None)
+        run(conn.add_remote_candidate(None))
         conn.remote_username = "foo"
         conn.remote_password = "bar"
         with self.assertRaises(ConnectionError) as cm:
@@ -1012,19 +1019,19 @@ class IceConnectionTest(unittest.TestCase):
         )
 
         # add candidate
-        conn_a.add_remote_candidate(remote_candidate)
+        run(conn_a.add_remote_candidate(remote_candidate))
         self.assertEqual(len(conn_a.remote_candidates), 1)
         self.assertEqual(conn_a.remote_candidates[0].host, "1.2.3.4")
         self.assertEqual(conn_a._remote_candidates_end, False)
 
         # end-of-candidates
-        conn_a.add_remote_candidate(None)
+        run(conn_a.add_remote_candidate(None))
         self.assertEqual(len(conn_a.remote_candidates), 1)
         self.assertEqual(conn_a._remote_candidates_end, True)
 
         # try adding another candidate
         with self.assertRaises(ValueError) as cm:
-            conn_a.add_remote_candidate(remote_candidate)
+            run(conn_a.add_remote_candidate(remote_candidate))
         self.assertEqual(
             str(cm.exception), "Cannot add remote candidate after end-of-candidates."
         )
@@ -1037,29 +1044,33 @@ class IceConnectionTest(unittest.TestCase):
         """
         conn_a = ice.Connection(ice_controlling=True)
 
-        conn_a.add_remote_candidate(
-            Candidate(
-                foundation="some-foundation",
-                component=1,
-                transport="udp",
-                priority=1234,
-                host="a64e1aa4-8c7e-4671-ab02-e6a3483b1cd9.local",
-                port=1234,
-                type="host",
+        run(
+            conn_a.add_remote_candidate(
+                Candidate(
+                    foundation="some-foundation",
+                    component=1,
+                    transport="udp",
+                    priority=1234,
+                    host="a64e1aa4-8c7e-4671-ab02-e6a3483b1cd9.local",
+                    port=1234,
+                    type="host",
+                )
             )
         )
         self.assertEqual(len(conn_a.remote_candidates), 0)
         self.assertEqual(conn_a._remote_candidates_end, False)
 
-        conn_a.add_remote_candidate(
-            Candidate(
-                foundation="some-foundation",
-                component=1,
-                transport="udp",
-                priority=1234,
-                host="1.2.3.4",
-                port=1234,
-                type="host",
+        run(
+            conn_a.add_remote_candidate(
+                Candidate(
+                    foundation="some-foundation",
+                    component=1,
+                    transport="udp",
+                    priority=1234,
+                    host="1.2.3.4",
+                    port=1234,
+                    type="host",
+                )
             )
         )
         self.assertEqual(len(conn_a.remote_candidates), 1)
@@ -1069,57 +1080,21 @@ class IceConnectionTest(unittest.TestCase):
     def test_add_remote_candidate_unknown_type(self):
         conn_a = ice.Connection(ice_controlling=True)
 
-        conn_a.add_remote_candidate(
-            Candidate(
-                foundation="some-foundation",
-                component=1,
-                transport="udp",
-                priority=1234,
-                host="1.2.3.4",
-                port=1234,
-                type="bogus",
+        run(
+            conn_a.add_remote_candidate(
+                Candidate(
+                    foundation="some-foundation",
+                    component=1,
+                    transport="udp",
+                    priority=1234,
+                    host="1.2.3.4",
+                    port=1234,
+                    type="bogus",
+                )
             )
         )
         self.assertEqual(len(conn_a.remote_candidates), 0)
         self.assertEqual(conn_a._remote_candidates_end, False)
-
-    def test_set_remote_candidates(self):
-        conn_a = ice.Connection(ice_controlling=True)
-
-        remote_candidates = [
-            Candidate(
-                foundation="some-foundation",
-                component=1,
-                transport="udp",
-                priority=1234,
-                host="1.2.3.4",
-                port=1234,
-                type="host",
-            )
-        ]
-
-        # set candidates
-        with warnings.catch_warnings(record=True) as w:
-            conn_a.remote_candidates = remote_candidates
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-            self.assertEqual(
-                str(w[0].message),
-                "Assigning Connection.remote_candidates is deprecated, use add_remote_candidate",
-            )
-        self.assertEqual(len(conn_a.remote_candidates), 1)
-        self.assertEqual(conn_a.remote_candidates[0].host, "1.2.3.4")
-        self.assertEqual(conn_a._remote_candidates_end, True)
-
-        # try setting candidates again
-        with warnings.catch_warnings():
-            with self.assertRaises(ValueError) as cm:
-                conn_a.remote_candidates = remote_candidates
-        self.assertEqual(
-            str(cm.exception), "Cannot set remote candidates after end-of-candidates."
-        )
-        self.assertEqual(len(conn_a.remote_candidates), 1)
-        self.assertEqual(conn_a._remote_candidates_end, True)
 
     @mock.patch("asyncio.base_events.BaseEventLoop.create_datagram_endpoint")
     def test_gather_candidates_oserror(self, mock_create):

--- a/tests/test_ice_trickle.py
+++ b/tests/test_ice_trickle.py
@@ -41,9 +41,9 @@ class IceTrickleTest(unittest.TestCase):
         async def add_candidates_later(a, b):
             await asyncio.sleep(0.1)
             for candidate in b.local_candidates:
-                a.add_remote_candidate(candidate)
+                await a.add_remote_candidate(candidate)
                 await asyncio.sleep(0.1)
-            a.add_remote_candidate(None)
+            await a.add_remote_candidate(None)
 
         # connect
         run(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,16 +7,16 @@ async def invite_accept(conn_a, conn_b):
     # invite
     await conn_a.gather_candidates()
     for candidate in conn_a.local_candidates:
-        conn_b.add_remote_candidate(candidate)
-    conn_b.add_remote_candidate(None)
+        await conn_b.add_remote_candidate(candidate)
+    await conn_b.add_remote_candidate(None)
     conn_b.remote_username = conn_a.local_username
     conn_b.remote_password = conn_a.local_password
 
     # accept
     await conn_b.gather_candidates()
     for candidate in conn_b.local_candidates:
-        conn_a.add_remote_candidate(candidate)
-    conn_a.add_remote_candidate(None)
+        await conn_a.add_remote_candidate(candidate)
+    await conn_a.add_remote_candidate(None)
     conn_a.remote_username = conn_b.local_username
     conn_a.remote_password = conn_b.local_password
 


### PR DESCRIPTION
Also remove the deprecated `remote_candidates` setter.