### PR TITLE
[turn] honour the LIFETIME returned by the server

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,15 @@ Changelog
 
 .. currentmodule:: aioice
 
+0.7.1
+-----
+
+TURN
+....
+
+ * Use the LIFETIME attribute returned by the server to determine the
+   time-to-expiry for the allocation.
+
 0.7.0
 -----
 


### PR DESCRIPTION
We must not assume the server accepted the LIFETIME requested by the
client for the allocation, use the actual value returned by the server.