### PR TITLE
[turn] periodically refresh channel binding (fixes: #29)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ TURN
    with an error.
  * Handle 438 (Stale Nonce) error responses.
  * Ignore STUN transaction errors when deleting TURN allocation.
+ * Periodically refresh channel bindings.
 
 0.7.0
 -----


### PR DESCRIPTION
Channel bindings expire after 600s. As our TURN implementation is used
with ICE (which uses consent queries), we will frequently send out data.
We take this opportunity to refresh the channel bindings as needed.