### PR TITLE
[mdns]: require dnspython >= 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,5 @@ setuptools.setup(
     package_dir={"": "src"},
     package_data={"aioice": ["py.typed"]},
     packages=["aioice"],
-    install_requires=["dnspython", "netifaces"],
+    install_requires=["dnspython>=2.0.0", "netifaces"],
 )


### PR DESCRIPTION
dnspython version 2.0.0 is the first one implementing QueryMessage on dns Message : see https://dnspython.readthedocs.io/en/stable/whatsnew.html#id2

Without it, aiortc crash with some exception:
````
Exception in callback _SelectorDatagramTransport._read_ready()
handle: <Handle _SelectorDatagramTransport._read_ready()>
Traceback (most recent call last):
  File "/usr/lib/python3.8/asyncio/events.py", line 81, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/lib/python3.8/asyncio/selector_events.py", line 1019, in _read_ready
    self._protocol.datagram_received(data, addr)
  File "/usr/local/lib/python3.8/dist-packages/aioice/mdns.py", line 55, in datagram_received
    if isinstance(message, dns.message.QueryMessage):
AttributeError: module 'dns.message' has no attribute 'QueryMessage'
````