### PR TITLE
[ice] connection_lost: local candidate may not have been set

### DIFF
--- a/src/aioice/ice.py
+++ b/src/aioice/ice.py
@@ -170,7 +170,8 @@ class StunProtocol(asyncio.DatagramProtocol):
 
     def connection_lost(self, exc: Exception) -> None:
         self.__log_debug("connection_lost(%s)", exc)
-        self.receiver.data_received(None, self.local_candidate.component)
+        if self.local_candidate is not None:
+            self.receiver.data_received(None, self.local_candidate.component)
         self.__closed.set_result(True)
 
     def connection_made(self, transport) -> None:


### PR DESCRIPTION
It could happen that the local candidate is not set when we enter `connection_lost`:
```
Traceback (most recent call last):                                                                  
  File "/usr/lib/python3.9/asyncio/events.py", line 80, in _run                                     
    self._context.run(self._callback, *self._args)                                                  
  File "/usr/lib/python3.9/asyncio/selector_events.py", line 736, in _call_connection_lost          
    self._protocol.connection_lost(exc)                                                             
  File "/home/ivan/venv-3.9/lib/python3.9/site-packages/aioice/ice.py", line 173, in connection_lost
    self.receiver.data_received(None, self.local_candidate.component)                               
AttributeError: 'NoneType' object has no attribute 'component'                                      
```