### PR TITLE
[tests] fix ssl deprecation warnings

### DIFF
--- a/tests/test_turn.py
+++ b/tests/test_turn.py
@@ -63,7 +63,8 @@ class TurnTest(unittest.TestCase):
 
     @asynctest
     async def test_tls_transport(self):
-        ssl_context = ssl.SSLContext()
+        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
+        ssl_context.check_hostname = False
         ssl_context.verify_mode = ssl.CERT_NONE
 
         await self._test_transport("tcp", "tls_address", ssl=ssl_context)

--- a/tests/turnserver.py
+++ b/tests/turnserver.py
@@ -351,7 +351,7 @@ class TurnServer:
         logger.info("Listening for UDP on %s", self.udp_address)
 
         # listen for TLS
-        ssl_context = ssl.SSLContext()
+        ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_SERVER)
         ssl_context.load_cert_chain(CERT_FILE, KEY_FILE)
         self.tls_server = await loop.create_server(
             lambda: TurnServerTcpProtocol(server=self),


### PR DESCRIPTION
If no `protocol` argument is passed to the `ssl.SSLContext()` constructor, it defaults to `ssl.PROTOCOL_TLS` which is deprecated since Python 3.10.

Explicitly use `ssl.PROTOCOL_TLS_CLIENT` or `ssl.PROTOCOL_TLS_SERVER` to fix the depreaction warning as these constants have been available since Python 3.6.