### PR TITLE
Optionally force gathering of only relay (STUN/TURN) candidates.

### DIFF
--- a/src/aioice/__init__.py
+++ b/src/aioice/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 from .about import __version__
 from .candidate import Candidate
-from .ice import Connection, ConnectionClosed
+from .ice import Connection, ConnectionClosed, TransportPolicy
 
 # Set default logging handler to avoid "No handler found" warnings.
 logging.getLogger(__name__).addHandler(logging.NullHandler())


### PR DESCRIPTION
Much like `iceTransportPolicy` in the [RTCPeerConnection configuration](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection). For example useful when testing STUN/TURN in a network where host candidates would otherwise be used.