### PR TITLE
Switch from `netifaces` to `ifaddr` (fixes: #62)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,6 @@ setuptools.setup(
     package_dir={"": "src"},
     package_data={"aioice": ["py.typed"]},
     packages=["aioice"],
-    install_requires=["dnspython>=2.0.0", "netifaces"],
+    install_requires=["dnspython>=2.0.0", "ifaddr>=0.2.0"],
     python_requires=">=3.7",
 )

--- a/src/aioice/mdns.py
+++ b/src/aioice/mdns.py
@@ -183,9 +183,7 @@ async def create_mdns_protocol() -> MDnsProtocol:
         rx_sock.bind((MDNS_ADDRESS, MDNS_PORT))
 
     _, protocol = await loop.create_datagram_endpoint(
-        lambda: MDnsProtocol(
-            tx_transport=cast(asyncio.DatagramTransport, tx_transport)
-        ),
+        lambda: MDnsProtocol(tx_transport=tx_transport),
         sock=rx_sock,
     )
 


### PR DESCRIPTION
The `netifaces` package is no longer maintained, so no new wheels are being published. As it is not a pure Python package, this means that installing `aioice` would require users to compile `netifaces` themselves which is not trivial on some platforms.

We use the `ifaddr` package instead, which is a pure Python package.