### PR TITLE
Fixed annotation for add_remote_candidate() to allow None

### DIFF
--- a/src/aioice/ice.py
+++ b/src/aioice/ice.py
@@ -382,7 +382,7 @@ class Connection:
         """
         return self._remote_candidates[:]
 
-    async def add_remote_candidate(self, remote_candidate: Candidate) -> None:
+    async def add_remote_candidate(self, remote_candidate: Optional[Candidate]) -> None:
         """
         Add a remote candidate or signal end-of-candidates.
 


### PR DESCRIPTION
I get errors from static type checkers when I pass None to signal the end of candidates. I would appreciate if this fix is merged to avoid adding unnecessary `# type: ignore` comments to the code