### PR TITLE
ICE gathering error handling

### DIFF
--- a/src/aioice/ice.py
+++ b/src/aioice/ice.py
@@ -996,31 +996,38 @@ class Connection:
         # connect to TURN server
         if self.turn_server:
             # create transport
-            _, protocol = await turn.create_turn_endpoint(
-                lambda: StunProtocol(self),
-                server_addr=self.turn_server,
-                username=self.turn_username,
-                password=self.turn_password,
-                ssl=self.turn_ssl,
-                transport=self.turn_transport,
-            )
-            self._protocols.append(protocol)
+            try:
+                _, protocol = await asyncio.wait_for(
+                    turn.create_turn_endpoint(
+                        lambda: StunProtocol(self),
+                        server_addr=self.turn_server,
+                        username=self.turn_username,
+                        password=self.turn_password,
+                        ssl=self.turn_ssl,
+                        transport=self.turn_transport,
+                    ),
+                    timeout=timeout,
+                )
 
-            # add relayed candidate
-            candidate_address = protocol.transport.get_extra_info("sockname")
-            related_address = protocol.transport.get_extra_info("related_address")
-            protocol.local_candidate = Candidate(
-                foundation=candidate_foundation("relay", "udp", candidate_address[0]),
-                component=component,
-                transport="udp",
-                priority=candidate_priority(component, "relay"),
-                host=candidate_address[0],
-                port=candidate_address[1],
-                type="relay",
-                related_address=related_address[0],
-                related_port=related_address[1],
-            )
-            candidates.append(protocol.local_candidate)
+                # add relayed candidate
+                candidate_address = protocol.transport.get_extra_info("sockname")
+                related_address = protocol.transport.get_extra_info("related_address")
+                protocol.local_candidate = Candidate(
+                    foundation=candidate_foundation("relay", "udp", candidate_address[0]),
+                    component=component,
+                    transport="udp",
+                    priority=candidate_priority(component, "relay"),
+                    host=candidate_address[0],
+                    port=candidate_address[1],
+                    type="relay",
+                    related_address=related_address[0],
+                    related_port=related_address[1],
+                )
+                candidates.append(protocol.local_candidate)
+            except Exception as e:
+                # We only log the error here.
+                # Even if TURN connection is failed, the gathered `candidates` should be returned.
+                logger.exception("Failed to create turn endpoint", exc_info=e)
 
         return candidates
 

--- a/src/aioice/turn.py
+++ b/src/aioice/turn.py
@@ -440,6 +440,7 @@ async def create_turn_endpoint(
         turn_transport = TurnTransport(protocol, inner_protocol)
         await turn_transport._connect()
     except Exception:
+        inner_protocol.receiver = None
         inner_transport.close()
         raise
 

--- a/src/aioice/turn.py
+++ b/src/aioice/turn.py
@@ -363,6 +363,7 @@ class TurnTransport:
         After the TURN allocation has been deleted, the protocol's
         `connection_lost()` method will be called with None as its argument.
         """
+        self.__inner_protocol.receiver = None
         asyncio.create_task(self.__inner_protocol.delete())
 
     def get_extra_info(self, name: str, default: Any = None) -> Any:
@@ -440,7 +441,7 @@ async def create_turn_endpoint(
         turn_transport = TurnTransport(protocol, inner_protocol)
         await turn_transport._connect()
     except Exception:
-        inner_protocol.receiver = None
+        turn_transport.close()
         inner_transport.close()
         raise
 


### PR DESCRIPTION
Resolves #16
Resolves #78


* TURN connection failure should be captured and other valid candidates should be preserved as https://github.com/aiortc/aioice/pull/84/files#diff-c59e3a1ebc2146a3d48a2a4001c15cc08f67ff6079aa445f6fbac1aec4b126b5R977-R980
* TURN connection trial should also be timed out like what is done for STUN as below. Otherwise the ICE gathering process lasts for long when the packet can't reach the specified TURN server soon.
  https://github.com/aiortc/aioice/blob/fc863fde4676e1f67dce981b7f9592ab02c6a09a/src/aioice/ice.py#L930

Discussions
* Seems like the [`onicecandidateerror` event](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/icecandidateerror_event) should be emitted from `RTCPeerConnection` in such a case. wdyt?