### PR TITLE
Delete print() in stun.py

### DIFF
--- a/src/aioice/stun.py
+++ b/src/aioice/stun.py
@@ -99,7 +99,6 @@ def unpack_address(
 
     # The remaining data represents a port and an address.
     port_address = data[2:]
-    print(len(port_address))
     if protocol == IPV4_PROTOCOL:
         # For IPv4 we expect 2 bytes for the port, 4 bytes for the address.
         if len(port_address) != 6:


### PR DESCRIPTION
nit: looks like this `print` is not intended to be in the code? 