### PR TITLE
Fix retry logic to prevent setting exception if future is already done

### DIFF
--- a/src/aioice/stun.py
+++ b/src/aioice/stun.py
@@ -326,7 +326,7 @@ class Transaction:
                 self.__timeout_handle.cancel()
 
     def __retry(self) -> None:
-        if self.__tries >= self.__tries_max:
+        if self.__tries >= self.__tries_max and not self.__future.done():
             self.__future.set_exception(TransactionTimeout())
             return
 


### PR DESCRIPTION
This pull request makes a small but important change to the retry logic in the `__retry` method of the `src/aioice/stun.py` file. The change ensures that the `TransactionTimeout` exception is not redundantly set if the future is already completed.

* [`src/aioice/stun.py`](diffhunk://#diff-f4c7788ad96fac6eacf253b57dae124e14ba8799450b41e9e1be6358fe4d0b71L329-R329): Modified the condition in the `__retry` method to check if the future (`self.__future`) is not already done before setting the `TransactionTimeout` exception. This prevents unnecessary operations and potential errors.

We experience this case in production here is the stacktrace:
```
Traceback (most recent call last):
  File "uvloop/cbhandles.pyx", line 253, in uvloop.loop.TimerHandle._run
  File "[masked]/aioice/stun.py", line 330, in __retry
    self.__future.set_exception(TransactionTimeout())
asyncio.exceptions.InvalidStateError: invalid state
```