### PR TITLE
Improvement for stun message logging representation

### DIFF
--- a/src/aioice/stun.py
+++ b/src/aioice/stun.py
@@ -261,7 +261,8 @@ class Message:
         return (
             f"Message(message_method=Method.{self.message_method.name}, "
             f"message_class=Class.{self.message_class.name}, "
-            f"transaction_id={repr(self.transaction_id)})"
+            f"transaction_id={self.transaction_id.hex()}, "
+            f"attributes={self.attributes})"
         )
 
 

--- a/tests/test_stun.py
+++ b/tests/test_stun.py
@@ -123,7 +123,7 @@ class MessageTest(unittest.TestCase):
         self.assertEqual(
             repr(message),
             "Message(message_method=Method.BINDING, message_class=Class.REQUEST, "
-            "transaction_id=b'Nvfx3lU7FUBF')",
+            "transaction_id=4e766678336c553746554246, attributes={})",
         )
 
     def test_binding_request_ice_controlled(self) -> None:


### PR DESCRIPTION
This will cover #108. Current stun message logs have the following shortcomings:
* transaction id is represented as a `b` binary string which is not really readable or convenient to search for;
* no additional attributes are displayed making it impossible to track error sources, etc.

This PR is aimed to fix both points.

Before: 
<img width="1898" height="113" alt="image" src="https://github.com/user-attachments/assets/cac3d8da-0b38-4f25-b319-c9c34a3b65f2" />

After:
```
 turn/udp > ('hostname.example', 3478) Message(message_method=Method.ALLOCATE, message_class=Class.REQUEST, transaction_id=47961dbdd44b9d346b6d60cd, attributes={'LIFETIME': 600, 'REQUESTED-TRANSPORT': 285212672})
 turn/udp < ('addr.example', 3478) Message(message_method=Method.ALLOCATE, message_class=Class.ERROR, transaction_id=47961dbdd44b9d346b6d60cd, attributes={'ERROR-CODE': (401, 'Unauthorized'), 'NONCE': b'6bd547705c319199', 'REALM': '...'})
 turn/udp > ('hostname.example', 3478) Message(message_method=Method.ALLOCATE, message_class=Class.REQUEST, transaction_id=d29c1aeee36c6ac72bafed7f, attributes={'LIFETIME': 600, 'REQUESTED-TRANSPORT': 285212672, 'USERNAME': '...', 'NONCE': b'6bd547705c319199', 'REALM': '...', 'MESSAGE-INTEGRITY': b'\xb2T\xdb V\r\xfe9\x8a\x0c\x83\x94\x87\xdaL9\xc9\xf81\x00', 'FINGERPRINT': 1000439827})
 turn/udp < ('addr.example', 3478) Message(message_method=Method.ALLOCATE, message_class=Class.ERROR, transaction_id=d29c1aeee36c6ac72bafed7f, attributes={'ERROR-CODE': (508, 'Cannot create socket'), 'MESSAGE-INTEGRITY': b'\x01\x01W\x7f\x91\xd5`\xdd\xe6\xc8\x11\xf4(\xd7\xca\xed\xd3n\x16\xa5', 'FINGERPRINT': 1730489432})
```
